### PR TITLE
chore: add markdownlint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,14 @@ repos:
       - id: check-added-large-files
       - id: detect-private-key
 
+  - repo: local
+    hooks:
+      - id: markdownlint
+        name: markdownlint
+        entry: markdownlint
+        language: system
+        types: [markdown]
+
   # Python (no hace nada si no hay .py)
   - repo: https://github.com/psf/black
     rev: 24.8.0

--- a/CODIGO_DE_CONDUCTA_Codex.md
+++ b/CODIGO_DE_CONDUCTA_Codex.md
@@ -1,3 +1,5 @@
+# Código de Conducta
+
 - No continuar ante fallos críticos (build/tests/credenciales).
 - Explicar decisiones en 1–2 líneas.
 - Proponer alternativa cuando se rechaza una orden por seguridad.

--- a/github/workflows/github/pull_request_template.md
+++ b/github/workflows/github/pull_request_template.md
@@ -1,15 +1,21 @@
+# Plantilla de Pull Request
+
 ## Contexto
+
 - ¿Qué problema resuelve?
 
 ## Cambios
+
 - Lista corta y clara.
 
 ## Pruebas
+
 - [ ] Unit
 - [ ] e2e
 - [ ] Manual notes
 
 ## Riesgos / Rollback
+
 - Cómo revertir si falla.
 
 > Si es **docs o solo comentarios**, incluye `[skip ci]` en el título del PR.


### PR DESCRIPTION
## Contexto
Se agrega validación de Markdown para reforzar estilo uniforme.

## Cambios
- Configuración de pre-commit con hook `markdownlint`.
- Ajustes en archivos Markdown para cumplir con las reglas.

## Pruebas
- `pre-commit run --all-files`

## Riesgos / Rollback
Riesgo bajo; revertir el commit en caso de problemas.

------
https://chatgpt.com/codex/tasks/task_e_689a291e04ac8331ae84db0fdcdfce99